### PR TITLE
Update dropdownContainer.js

### DIFF
--- a/src/components/dropdownContainer.js
+++ b/src/components/dropdownContainer.js
@@ -54,7 +54,10 @@ class RuuiDropdownContainer extends Component {
 			onPress={this.onPress}
 			onLongPress={this.onLongPress}
 			{...otherProps}>
-			<View style={style} ref={(container) => { this.container = container; }}>
+			<View 
+			 renderToHardwareTextureAndroid
+			 style={style}
+			 ref={(container) => { this.container = container; }}>
 				{children}
 			</View>
 		</TouchableOpacity>;


### PR DESCRIPTION
Add `renderToHardwareTextureAndroid` props to the container view to make sure the `measure` method work on Android. On Android, `measure` will always return undefined so dropdown will not work properly