### PR TITLE
ruui.config.js can change development port and host.

### DIFF
--- a/cli/addons/ssr/ruui.config.js
+++ b/cli/addons/ssr/ruui.config.js
@@ -1,7 +1,11 @@
-const env = () => process.env.ENV || 'development',
-	isProduction = env() === 'production';
+const env = () => process.env.ENV || 'development';
+const host = () => process.env.HOST || 'localhost';
+const port = () => process.env.DEV_PORT || 3000;
+const isProduction = env() === 'production';
+
 
 module.exports = {
 	env,
-	publicPath: isProduction ? '/' : 'http://localhost:3000/',
+	publicPath: isProduction ? '/' : `http://${host()}:${port()}/`,
+	port
 };


### PR DESCRIPTION
now can't change webpack dev server port number.  
this PR is can change port number by ENV (like DEV_PORT=3010)