### PR TITLE
- Update dropdown container use measureLayout instead of measure

### DIFF
--- a/src/components/dropdown.js
+++ b/src/components/dropdown.js
@@ -9,6 +9,7 @@ type Props = {
 	dispatch?: Function,
 	active?: boolean,
 	configs?: DropdownConfigs,
+	screenSize?: { width?: number, height?: number },
 };
 
 @connect(() => ({}))
@@ -62,7 +63,7 @@ class RuuiDropdown extends Component {
 	}
 
 	renderDropDown() {
-		const { configs } = this.props,
+		const { configs, screenSize } = this.props,
 			{ layout, } = this.state,
 			context = configs.context || {},
 			positionOffset = configs.offset || { top: 0, left: 0 },
@@ -77,7 +78,8 @@ class RuuiDropdown extends Component {
 				containerLayout.y, containerLayout.x,
 				containerLayout.width, containerLayout.height,
 				layout.width, layout.height,
-				configs.direction, configs.spacing
+				configs.direction, configs.spacing,
+				screenSize,
 			),
 			wrapperStyles = {
 				overflow: 'hidden',

--- a/src/components/dropdownContainer.js
+++ b/src/components/dropdownContainer.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { View, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, TouchableOpacity, StyleSheet, findNodeHandle } from 'react-native';
 
 import * as appActions from '../utils/store/appAction';
 import { Style, Element, SnappingDirection, Layout, } from '../typeDefinition';
@@ -90,12 +90,12 @@ class RuuiDropdownContainer extends Component {
 			onClose,
 		} = this.props;
 
-		this.container.measure((a, b, width, height, px, py) => {
+		this.container.measureLayout(findNodeHandle(global.modalsContainer), (a, b, width, height) => {
 			this.store.dispatch(appActions.toggleDropdown(true, {
 				id: id || `Dropdown_${Math.random()}`,
 				wrapperStyle: dropdownWrapperStyle,
 				component: dropdownComponent,
-				containerLayout: containerLayout || { x: px, y: py, width, height, },
+				containerLayout: containerLayout || { x: a, y: b, width, height, },
 				direction: dropdownDirection,
 				spacing: dropdownSpacing,
 				offset: dropdownOffset,

--- a/src/components/modals.js
+++ b/src/components/modals.js
@@ -9,6 +9,7 @@ import RuuiDropdown from './dropdown';
 type Props = {
 	modals?: Array<Object>,
 	dispatch?: Function,
+	screenSize?: { width?: number, height?: number },
 };
 
 @connect(({ activeModals }) => {
@@ -21,16 +22,18 @@ class RuuiModals extends Component {
 	props: Props;
 
 	render() {
-		const { dispatch, modals } = this.props,
+		const { dispatch, modals, screenSize } = this.props,
 			modalArray = Object.keys(modals).map(key => Object.assign({}, modals[key], { id: key }));
 
 		return <View
+			ref={(ref) => { global.modalsContainer = ref; }}
 			pointerEvents="box-none"
 			style={styles.container}>
 			{modalArray.map((modalConfigs, i) => {
 				if (modalConfigs.type === 'dropdown') {
 					return <RuuiDropdown
 						key={i}
+						screenSize={screenSize}
 						{...modalConfigs}
 					/>;
 				}

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -13,8 +13,8 @@ export function debounce(fn, duration) {
 }
 
 export function uuid() {
-	return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-		const r = Math.random()*16|0, v = c === 'x' ? r : (r&0x3|0x8);
+	return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+		const r = Math.random() * 16 | 0, v = c === 'x' ? r : (r & 0x3 | 0x8);
 		return v.toString(16);
 	});
 }
@@ -36,22 +36,22 @@ export function maxGuard(value: Number, gap: Number) {
 	return value > gap ? gap : value;
 }
 
-const defaultIteratee = (item) => item;
+const defaultIteratee = item => item;
 
 export function maxBy(array, iteratee = defaultIteratee) {
-	let result
-	if (array == null) return result
+	let result;
+	if (array == null) return result;
 
-	let computed
+	let computed;
 	for (const value of array) {
-		const current = iteratee(value)
+		const current = iteratee(value);
 
 		if (current != null && (computed === undefined ? current === current : current > computed)) {
-			computed = current
-			result = value
+			computed = current;
+			result = value;
 		}
 	}
-	return result
+	return result;
 }
 
 export function clamp(value: Number, min: Number, max: Number) {
@@ -73,8 +73,8 @@ function is(x, y) {
 export function shallowEqual(objA, objB) {
 	if (is(objA, objB)) return true;
 
-	if (typeof objA !== 'object' || objA === null ||
-		typeof objB !== 'object' || objB === null) {
+	if (typeof objA !== 'object' || objA === null
+		|| typeof objB !== 'object' || objB === null) {
 		return false;
 	}
 
@@ -84,8 +84,8 @@ export function shallowEqual(objA, objB) {
 	if (keysA.length !== keysB.length) return false;
 
 	for (let i = 0; i < keysA.length; i += 1) {
-		if (!hasOwn.call(objB, keysA[i]) ||
-			!is(objA[keysA[i]], objB[keysA[i]])) {
+		if (!hasOwn.call(objB, keysA[i])
+			|| !is(objA[keysA[i]], objB[keysA[i]])) {
 			return false;
 		}
 	}
@@ -182,8 +182,8 @@ function rawDirectionSnap(
 }
 
 /* <- to make sure floating component's position won't exceed screen's visible area */
-function screenGuard(position, componentSize, screenPadding = 5) {
-	const screenSize = Dimensions.get('window'),
+function screenGuard(position, componentSize, screenPadding = 5, moddedScreenSize = {}) {
+	const screenSize = { ...Dimensions.get('window'), ...moddedScreenSize },
 		{ top, left, } = position;
 	let guardedTop = top, guardedLeft = left;
 
@@ -207,15 +207,17 @@ export function directionSnap(
 	width2: number = 0, height2: number = 0,
 	position: SnappingDirection = 'bottom',
 	spacing = 10,
+	screenSize,
 ) {
 	return screenGuard(
 		rawDirectionSnap(top, left, width1, height1, width2, height2, position, spacing),
-		{ width: width2, height: height2, },
+		{ width: width2, height: height2, }, 5, screenSize
 	);
 }
 
 export function directionAnimatedConfigs(
-	direction, translateDistance, animation, finalBorderRadius = 3) {
+	direction, translateDistance, animation, finalBorderRadius = 3
+) {
 	const borderRadius = animation.interpolate({
 			inputRange: [0, 0.5, 1], outputRange: [50, 15, finalBorderRadius],
 		}),


### PR DESCRIPTION
Handle dropdown in advance usage (screen is zoomed out, ....) when containerSize is different from screen size